### PR TITLE
Rename

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-# Copyright (c) 2025 scalable_echo_server_demo Contributors
+# Copyright (c) 2025 WinUDPShardedEcho Contributors
 
 BasedOnStyle: Google
 IndentWidth: 4

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,7 +1,7 @@
 name: CI/CD
 
 # SPDX-License-Identifier: MIT
-# Copyright (c) 2025 scalable_echo_server_demo contributors
+# Copyright (c) 2025 WinUDPShardedEcho contributors
 
 on:
   push:

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -1,7 +1,7 @@
 name: Reusable Build
 
 # SPDX-License-Identifier: MIT
-# Copyright (c) 2025 scalable_echo_server_demo contributors
+# Copyright (c) 2025 WinUDPShardedEcho contributors
 
 on:
   workflow_call:
@@ -21,7 +21,7 @@ on:
       repository: # Default to this repository if not provided
         required: false
         type: string
-        default: alan-jowett/scalable_echo_server_demo
+        default: alan-jowett/WinUDPShardedEcho
       
 
 jobs:

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -1,7 +1,7 @@
 name: Reusable Test
 
 # SPDX-License-Identifier: MIT
-# Copyright (c) 2025 scalable_echo_server_demo contributors
+# Copyright (c) 2025 WinUDPShardedEcho contributors
 
 on:
   workflow_call:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: MIT
-# © scalable_echo_server_demo Contributors. All rights reserved.
+# © WinUDPShardedEcho Contributors. All rights reserved.
 
 cmake_minimum_required(VERSION 3.20)
 
-project(scalable_echo_server_demo LANGUAGES CXX)
+project(WinUDPShardedEcho LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 <!-- SPDX-License-Identifier: MIT
-  Copyright (c) 2025 scalable_echo_server_demo contributors -->
-# Contributing to scalable_echo_server_demo
+  Copyright (c) 2025 WinUDPShardedEcho contributors -->
+# Contributing to WinUDPShardedEcho
 
-Thanks for helping improve `scalable_echo_server_demo` — a small C++ echo server / client demo used to illustrate scalable I/O patterns and build/test workflows on Windows (MSVC + CMake).
+Thanks for helping improve `WinUDPShardedEcho` — a small C++ echo server / client demo used to illustrate scalable I/O patterns and build/test workflows on Windows (MSVC + CMake).
 
 Please read the guidelines below before opening issues or pull requests.
 
@@ -13,8 +13,8 @@ Please read the guidelines below before opening issues or pull requests.
 1. Fork the repository on GitHub and clone your fork locally:
 
 ```pwsh
-git clone https://github.com/<your-username>/scalable_echo_server_demo.git
-cd scalable_echo_server_demo
+git clone https://github.com/<your-username>/WinUDPShardedEcho.git
+cd WinUDPShardedEcho
 ```
 
 2. Create a feature branch:
@@ -32,7 +32,7 @@ cmake -S .. -B . -A x64
 cmake --build . --config Release
 ```
 
-Or open `build/scalable_echo_server_demo.sln` in Visual Studio and build from the IDE.
+Or open `build/WinUDPShardedEcho.sln` in Visual Studio and build from the IDE.
 
 ---
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 scalable_echo_server_demo contributors
+Copyright (c) 2025 WinUDPShardedEcho contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- SPDX-License-Identifier: MIT
-  Copyright (c) 2025 scalable_echo_server_demo contributors -->
+  Copyright (c) 2025 WinUDPShardedEcho contributors -->
 
-# Scalable Echo Server Demo
+# WinUDPShardedEcho - A Scalable Echo Server Demo
 
 This implements RFC 862 - [Echo Protocol](https://www.rfc-editor.org/rfc/rfc862)
 

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -1,6 +1,6 @@
 <!--
 SPDX-License-Identifier: MIT
-Copyright (c) 2025 scalable_echo_server_demo contributors
+Copyright (c) 2025 WinUDPShardedEcho contributors
 -->
 This repository uses GitHub Copilot and the GitHub Copilot coding agent guidance.
 

--- a/scripts/check-format
+++ b/scripts/check-format
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
-# Copyright (c) 2025 scalable_echo_server_demo Contributors
+# Copyright (c) 2025 WinUDPShardedEcho Contributors
 #
 # Core formatting/check logic (POSIX). This file is the single source of truth
 # for formatting/cppcheck behavior. Wrapper scripts call this when `sh`/`bash`

--- a/scripts/check-format.ps1
+++ b/scripts/check-format.ps1
@@ -1,6 +1,6 @@
 <#
 SPDX-License-Identifier: MIT
-Copyright (c) 2025 scalable_echo_server_demo Contributors
+Copyright (c) 2025 WinUDPShardedEcho Contributors
 #>
 
 param(

--- a/scripts/check-format.sh
+++ b/scripts/check-format.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
-# Copyright (c) 2025 scalable_echo_server_demo Contributors
+# Copyright (c) 2025 WinUDPShardedEcho Contributors
 set -euo pipefail
 
 # Default: check staged or modified files. Use --all to check entire repo.

--- a/scripts/extensions.sh
+++ b/scripts/extensions.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
-# Copyright (c) 2025 scalable_echo_server_demo Contributors
+# Copyright (c) 2025 WinUDPShardedEcho Contributors
 # Canonical file extension lists used by format/static-check scripts.
 
 # C/C++ source/header extensions used for formatting and static analysis

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
-# Copyright (c) 2025 scalable_echo_server_demo Contributors
+# Copyright (c) 2025 WinUDPShardedEcho Contributors
 
 # Pre-commit hook: run the repository formatting/check helper. This hook is
 # intentionally lightweight: it calls `scripts/check-format.sh` (on POSIX) or

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 scalable_echo_server_demo Contributors
+// Copyright (c) 2025 WinUDPShardedEcho Contributors
 // SPDX-License-Identifier: MIT
 
 // Scalable UDP Echo Client

--- a/src/common/arg_parser.hpp
+++ b/src/common/arg_parser.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 scalable_echo_server_demo Contributors
+// Copyright (c) 2025 WinUDPShardedEcho Contributors
 // SPDX-License-Identifier: MIT
 #pragma once
 

--- a/src/common/socket_utils.cpp
+++ b/src/common/socket_utils.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 scalable_echo_server_demo Contributors
+// Copyright (c) 2025 WinUDPShardedEcho Contributors
 // SPDX-License-Identifier: MIT
 
 #include "socket_utils.hpp"

--- a/src/common/socket_utils.hpp
+++ b/src/common/socket_utils.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 scalable_echo_server_demo Contributors
+// Copyright (c) 2025 WinUDPShardedEcho Contributors
 // SPDX-License-Identifier: MIT
 
 #pragma once

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 scalable_echo_server_demo Contributors
+// Copyright (c) 2025 WinUDPShardedEcho Contributors
 // SPDX-License-Identifier: MIT
 
 // Scalable UDP Echo Server


### PR DESCRIPTION
This pull request performs a comprehensive rename of the project from `scalable_echo_server_demo` to `WinUDPShardedEcho`. The changes update all references across source files, scripts, documentation, CMake configuration, and GitHub workflow files to reflect the new project name and copyright holder.

Key changes include:

**Project and Copyright Renaming:**

* Updated the project name from `scalable_echo_server_demo` to `WinUDPShardedEcho` in `CMakeLists.txt`, source files, and all scripts. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL2-R6) [[2]](diffhunk://#diff-0ba42df560ab77c250cbab896ad90bd4f63568ff1fa11b5e2ee8eddfd2ed964dL1-R1) [[3]](diffhunk://#diff-d2903e164ee90b8f29df93dbbd7cb9ccd97f567285fec1cc7bb564ed061662f1L1-R1) [[4]](diffhunk://#diff-bd5e89fe07dc5ec2382ba35184d0caf52a7e7f85a2eb2927dc4dabde2a47fe75L1-R1) [[5]](diffhunk://#diff-d4800f35c68e179c407fc8852583d68443dd4aef1ff093976cfb038a3744cabeL1-R1) [[6]](diffhunk://#diff-fabb019e91e347b89a38879bbb26f5d9493b1157bd6fb4d7bb1016e5619108a2L1-R1) [[7]](diffhunk://#diff-1026e0038b722990204a42bed8a6f7c0ec2302aa79e3fad1959d62ba968edfa2L2-R2) [[8]](diffhunk://#diff-b43e682e2b68259e03b760ed964386041606324aedfbf573b77bf72d737a539aL3-R3) [[9]](diffhunk://#diff-9508b48face0fc02bee1d3d0a27bdbb2d7ce9acb550c7b2af47b592d811d10bbL3-R3) [[10]](diffhunk://#diff-53f91287579040bd572d0e90c04cc6ce5a27f575acac788bc35102a034a034d1L3-R3) [[11]](diffhunk://#diff-0b961f56900cfd6e0c756dd1875395bff4a6039a6360550dfea6146da59489f5L3-R3) [[12]](diffhunk://#diff-40564a4a456c31b8543923ab58e31689dde6119d9419c1211a0cbee86a524debL3-R3)
* Changed the copyright holder to `WinUDPShardedEcho contributors` or `WinUDPShardedEcho Contributors` throughout all files, including scripts, documentation, and license. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL2-R6) [[2]](diffhunk://#diff-1026e0038b722990204a42bed8a6f7c0ec2302aa79e3fad1959d62ba968edfa2L2-R2) [[3]](diffhunk://#diff-b43e682e2b68259e03b760ed964386041606324aedfbf573b77bf72d737a539aL3-R3) [[4]](diffhunk://#diff-9508b48face0fc02bee1d3d0a27bdbb2d7ce9acb550c7b2af47b592d811d10bbL3-R3) [[5]](diffhunk://#diff-53f91287579040bd572d0e90c04cc6ce5a27f575acac788bc35102a034a034d1L3-R3) [[6]](diffhunk://#diff-0b961f56900cfd6e0c756dd1875395bff4a6039a6360550dfea6146da59489f5L3-R3) [[7]](diffhunk://#diff-40564a4a456c31b8543923ab58e31689dde6119d9419c1211a0cbee86a524debL3-R3) [[8]](diffhunk://#diff-0ba42df560ab77c250cbab896ad90bd4f63568ff1fa11b5e2ee8eddfd2ed964dL1-R1) [[9]](diffhunk://#diff-d2903e164ee90b8f29df93dbbd7cb9ccd97f567285fec1cc7bb564ed061662f1L1-R1) [[10]](diffhunk://#diff-bd5e89fe07dc5ec2382ba35184d0caf52a7e7f85a2eb2927dc4dabde2a47fe75L1-R1) [[11]](diffhunk://#diff-d4800f35c68e179c407fc8852583d68443dd4aef1ff093976cfb038a3744cabeL1-R1) [[12]](diffhunk://#diff-fabb019e91e347b89a38879bbb26f5d9493b1157bd6fb4d7bb1016e5619108a2L1-R1) [[13]](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L3-R3) [[14]](diffhunk://#diff-8478dc8715bd3bb5375896278c40bfe10884164a7b33c421a880384076f1f8f2L3-R3)

**Documentation and Instructions:**

* Updated all documentation (`README.md`, `CONTRIBUTING.md`, `LICENSE`, `copilot-instructions.md`) to use the new project name and copyright. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2-R4) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L2-R5) [[3]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L16-R17) [[4]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L35-R35) [[5]](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L3-R3) [[6]](diffhunk://#diff-8478dc8715bd3bb5375896278c40bfe10884164a7b33c421a880384076f1f8f2L3-R3)

**Build and Workflow Configuration:**

* Changed the project name and repository references in GitHub Actions workflows and CMake configuration to `WinUDPShardedEcho`. [[1]](diffhunk://#diff-6727e33ccc9195d67f0786e1384f8f1cdaf4090c3e77547943105bd2b28c99d0L4-R4) [[2]](diffhunk://#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L4-R4) [[3]](diffhunk://#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L24-R24) [[4]](diffhunk://#diff-e386584fe70c301924ab6a8d4656b54ef92ed1961e6eb6f77c155be3475615f6L4-R4) [[5]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL2-R6)

No functional or behavioral changes to the codebase are included in this pull request; all changes are related to renaming and project identity.