### PR TITLE
Ignore connection reset messages

### DIFF
--- a/src/common/socket_utils.cpp
+++ b/src/common/socket_utils.cpp
@@ -241,7 +241,8 @@ void post_recv(const unique_socket& sock, io_context* ctx) {
 
     if (result == SOCKET_ERROR) {
         int error = WSAGetLastError();
-        if (error != WSA_IO_PENDING) {
+        // Ignore WSAECONNRESET which can happen with UDP when no one is listening
+        if (error != WSA_IO_PENDING && error != WSAECONNRESET) {
             std::cerr << std::format("WSARecvFrom failed: {} ({})\n", get_last_error_message(),
                                      error);
         }


### PR DESCRIPTION
This pull request makes a minor improvement to error handling in the `post_recv` function. The change ensures that the `WSAECONNRESET` error, which can occur with UDP when no one is listening, is now ignored, preventing unnecessary error messages from being logged.

* Updated error handling in `post_recv` to ignore `WSAECONNRESET` for UDP sockets, reducing spurious error logs.