### PR TITLE
Sync reply

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,3 +174,22 @@ The client tracks and reports:
 ## License
 
 MIT License - See [LICENSE](LICENSE) for details
+
+## Synchronous Replies vs Overlapped IO
+
+The server supports two reply modes: synchronous blocking replies using `sendto` (enabled
+with `--sync-reply`) and asynchronous overlapped sends using IO Completion Ports (the default).
+Choose based on your workload and goals:
+
+- **Latency (low load):** Synchronous replies can be slightly faster for very small, low-concurrency
+   workloads because they avoid queuing and completion handling overhead.
+- **Throughput (high load):** Overlapped IO with IOCP scales much better under concurrency and
+   network load. Synchronous sends may block a worker thread and cause head-of-line blocking.
+- **Resource model:** Synchronous sends do not consume send-context slots or generate completion
+   events, while overlapped sends use explicit contexts and IOCP notifications.
+- **Robustness and backpressure:** IOCP-based sends are non-blocking and integrate with the OS
+   queuing model; synchronous sends can fail or block and require inline error handling.
+
+Recommendation: keep the default overlapped IO for production and high-throughput testing. Use
+`--sync-reply` for small experiments, micro-benchmarks, or when you explicitly want the simpler
+blocking send path for diagnosis.

--- a/src/common/socket_utils.cpp
+++ b/src/common/socket_utils.cpp
@@ -304,6 +304,17 @@ void post_send(const unique_socket& sock, io_context* ctx, const char* data, siz
     }
 }
 
+    int send_sync(const unique_socket& sock, const char* data, size_t len, const sockaddr* dest_addr,
+                  int dest_addr_len) {
+        // For UDP, sendto either sends the full datagram or fails.
+        int to_send = static_cast<int>(std::min<size_t>(len, INT_MAX));
+        int sent = sendto(sock.get(), data, to_send, 0, dest_addr, dest_addr_len);
+        if (sent == SOCKET_ERROR) {
+            throw socket_exception(std::format("sendto failed: {}", get_last_error_message()));
+        }
+        return sent;
+    }
+
 /**
  * @brief Retrieve the local socket name (getsockname) for `sock`.
  *

--- a/src/common/socket_utils.hpp
+++ b/src/common/socket_utils.hpp
@@ -219,6 +219,14 @@ void post_send(const unique_socket& sock, io_context* ctx, const char* data, siz
                const sockaddr* dest_addr, int dest_addr_len);
 
 /**
+ * @brief Synchronously send a UDP datagram using `sendto`.
+ *
+ * Returns number of bytes sent on success, or throws socket_exception on error.
+ */
+int send_sync(const unique_socket& sock, const char* data, size_t len, const sockaddr* dest_addr,
+              int dest_addr_len);
+
+/**
  * @brief Return a monotonic timestamp in nanoseconds.
  */
 uint64_t get_timestamp_ns();


### PR DESCRIPTION
This pull request introduces support for synchronous UDP replies using `sendto` as an alternative to the existing asynchronous IO Completion Port (IOCP) mechanism. It adds a new `--sync-reply` flag to the server, allowing users to choose between synchronous and asynchronous reply modes, and updates the documentation to explain the trade-offs. Additionally, it improves error handling and IOCP setup robustness.

**Synchronous reply mode support:**

* Added a new `--sync-reply` command-line flag to the server, enabling synchronous blocking replies via `sendto` instead of the default overlapped IOCP sends. This is controlled by the new `g_sync_reply` flag and integrated into the worker thread logic. [[1]](diffhunk://#diff-fabb019e91e347b89a38879bbb26f5d9493b1157bd6fb4d7bb1016e5619108a2R47-R48) [[2]](diffhunk://#diff-fabb019e91e347b89a38879bbb26f5d9493b1157bd6fb4d7bb1016e5619108a2R181-R196) [[3]](diffhunk://#diff-fabb019e91e347b89a38879bbb26f5d9493b1157bd6fb4d7bb1016e5619108a2R258) [[4]](diffhunk://#diff-fabb019e91e347b89a38879bbb26f5d9493b1157bd6fb4d7bb1016e5619108a2R276) [[5]](diffhunk://#diff-fabb019e91e347b89a38879bbb26f5d9493b1157bd6fb4d7bb1016e5619108a2R290-R296)
* Implemented the `send_sync` function for sending UDP datagrams synchronously, with error handling, and exposed it in the socket utilities header. [[1]](diffhunk://#diff-bd5e89fe07dc5ec2382ba35184d0caf52a7e7f85a2eb2927dc4dabde2a47fe75R307-R317) [[2]](diffhunk://#diff-d4800f35c68e179c407fc8852583d68443dd4aef1ff093976cfb038a3744cabeR221-R228)

**Documentation improvements:**

* Updated `README.md` to document the differences between synchronous and asynchronous reply modes, including performance and robustness trade-offs, and recommendations for usage.

**IOCP and socket utilities robustness:**

* Improved IOCP association logic by ensuring completion notification modes are set using the new `set_file_completion_notification_modes` wrapper, which throws on failure. This function is now exposed in the header and used during IOCP setup and socket association. [[1]](diffhunk://#diff-bd5e89fe07dc5ec2382ba35184d0caf52a7e7f85a2eb2927dc4dabde2a47fe75R98-R100) [[2]](diffhunk://#diff-bd5e89fe07dc5ec2382ba35184d0caf52a7e7f85a2eb2927dc4dabde2a47fe75R120-R131) [[3]](diffhunk://#diff-d4800f35c68e179c407fc8852583d68443dd4aef1ff093976cfb038a3744cabeR173-R182)
* Enhanced error handling in `post_recv` to ignore `WSAECONNRESET` errors, which are expected with UDP when no receiver is present.