### PR TITLE
Set default to increase entropy

### DIFF
--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -331,7 +331,7 @@ int main(int argc, char* argv[]) try {
     parser.add_option("duration", 'd', "10", true);
     parser.add_option("rate", 'r', "10000", true);
     parser.add_option("recvbuf", 'b', "4194304", true);
-    parser.add_option("sockets", 'k', "1", true);
+    parser.add_option("sockets", 'k', "16", true);
     parser.add_option("help", 'h', "0", false);
 
     parser.parse(argc, argv);


### PR DESCRIPTION
This pull request makes a small change to the default configuration for the client application. The default number of sockets used is increased from 1 to 16, which may improve throughput or parallelism in network operations.

* Default value for the `sockets` option in `src/client/main.cpp` is changed from 1 to 16.