### PR TITLE
Fix rio

### DIFF
--- a/src/common/socket_utils.cpp
+++ b/src/common/socket_utils.cpp
@@ -439,6 +439,8 @@ std::string get_last_error_message() {
         message = std::format("Error code {}", error);
     }
 
+    message += std::format(" (code {})", error);
+
     return message;
 }
 
@@ -477,12 +479,10 @@ RIO_EXTENSION_FUNCTION_TABLE load_rio_function_table(const unique_socket& sock) 
 unique_rio_cq create_rio_completion_queue(const RIO_EXTENSION_FUNCTION_TABLE& rio, DWORD queue_size, unique_event& notification_event) {
     // Create a completion queue.
     RIO_NOTIFICATION_COMPLETION notification = {};
-    if (notification_event == nullptr) {
-        notification.Type = RIO_EVENT_COMPLETION;
-        notification.Event.EventHandle = notification_event.get();
-        notification.Event.NotifyReset = TRUE;
-    }
-    RIO_CQ cq = rio.RIOCreateCompletionQueue(queue_size, notification_event ? &notification : nullptr);
+    notification.Type = RIO_EVENT_COMPLETION;
+    notification.Event.EventHandle = notification_event.get();
+    notification.Event.NotifyReset = TRUE;
+    RIO_CQ cq = rio.RIOCreateCompletionQueue(queue_size, &notification);
     if (cq == RIO_INVALID_CQ) {
         throw socket_exception(
             std::format("RIOCreateCompletionQueue failed: {}", get_last_error_message()));


### PR DESCRIPTION
This pull request makes minor improvements to the error reporting and the creation of RIO completion queues in the `src/common/socket_utils.cpp` file.

Error reporting enhancement:

* The `get_last_error_message()` function now appends the error code in parentheses to the returned message for clearer diagnostics.

RIO completion queue creation simplification:

* The `create_rio_completion_queue` function now always initializes the `notification` structure and passes its address to `RIOCreateCompletionQueue`, removing unnecessary conditional logic.