### PR TITLE
Batch RIO traffic

### DIFF
--- a/src/common/socket_utils.hpp
+++ b/src/common/socket_utils.hpp
@@ -473,6 +473,26 @@ unique_rio_buffer register_rio_buffer(const RIO_EXTENSION_FUNCTION_TABLE& rio, v
 void post_rio_recv(const RIO_EXTENSION_FUNCTION_TABLE& rio, RIO_RQ rq, rio_context* ctx);
 
 /**
+ * @brief Post multiple RIO receive operations in batch.
+ *
+ * Submits multiple receive operations to the RIO request queue in a single call
+ * by building RIO_BUF arrays and passing them to RIOReceiveEx. This is more
+ * efficient than posting operations individually.
+ *
+ * Example usage:
+ * @code
+ * std::vector<rio_context*> recv_contexts = {...};
+ * post_rio_recv(rio_table, request_queue, recv_contexts);
+ * @endcode
+ *
+ * @param rio RIO function table.
+ * @param rq Request queue.
+ * @param contexts Vector of RIO contexts to post receives for.
+ * @throws socket_exception if the batch operation fails.
+ */
+void post_rio_recv(const RIO_EXTENSION_FUNCTION_TABLE& rio, RIO_RQ rq, const std::vector<rio_context*>& contexts);
+
+/**
  * @brief Post a RIO send operation.
  *
  * @param rio RIO function table.
@@ -481,5 +501,29 @@ void post_rio_recv(const RIO_EXTENSION_FUNCTION_TABLE& rio, RIO_RQ rq, rio_conte
  * @param len Length of data to send.
  */
 void post_rio_send(const RIO_EXTENSION_FUNCTION_TABLE& rio, RIO_RQ rq, rio_context* ctx, DWORD length);
+
+/**
+ * @brief Post multiple RIO send operations in batch.
+ *
+ * Submits multiple send operations to the RIO request queue in a single call
+ * by building RIO_BUF arrays and passing them to RIOSendEx. This is more
+ * efficient than posting operations individually.
+ *
+ * Example usage:
+ * @code
+ * std::vector<std::pair<rio_context*, DWORD>> send_ops = {
+ *     {ctx1, 100},  // Send 100 bytes from ctx1
+ *     {ctx2, 256},  // Send 256 bytes from ctx2
+ * };
+ * post_rio_send(rio_table, request_queue, send_ops);
+ * @endcode
+ *
+ * @param rio RIO function table.
+ * @param rq Request queue.
+ * @param send_data Vector of pairs containing rio_context pointer and data length.
+ * @throws socket_exception if the batch operation fails.
+ */
+void post_rio_send(const RIO_EXTENSION_FUNCTION_TABLE& rio, RIO_RQ rq, 
+                   const std::vector<std::pair<rio_context*, DWORD>>& send_data);
 
 //@}


### PR DESCRIPTION
This pull request introduces efficient batching for RIO (Registered I/O) send and receive operations, improving performance and code clarity in both the socket utility library and the server worker thread. Instead of posting individual send/receive operations, the code now collects them into batches and submits them together, reducing context switching and improving CPU cache locality.

**Batch RIO operation support:**

* Added new functions `post_rio_recv` and `post_rio_send` to `socket_utils.cpp` and declared them in `socket_utils.hpp` to support posting multiple RIO receive/send operations in a single batch. These functions iterate over provided contexts and submit each operation, with improved documentation and usage examples. [[1]](diffhunk://#diff-bd5e89fe07dc5ec2382ba35184d0caf52a7e7f85a2eb2927dc4dabde2a47fe75R593-R662) [[2]](diffhunk://#diff-d4800f35c68e179c407fc8852583d68443dd4aef1ff093976cfb038a3744cabeR475-R494) [[3]](diffhunk://#diff-d4800f35c68e179c407fc8852583d68443dd4aef1ff093976cfb038a3744cabeR505-R528)

**Server worker thread batching logic:**

* Refactored the worker thread in `main.cpp` to collect send and receive operations in vectors (`recv_repost`, `send_batch`) during completion processing, and batch-submit them after processing all completions, replacing previous per-operation submission. [[1]](diffhunk://#diff-fabb019e91e347b89a38879bbb26f5d9493b1157bd6fb4d7bb1016e5619108a2L314-R321) [[2]](diffhunk://#diff-fabb019e91e347b89a38879bbb26f5d9493b1157bd6fb4d7bb1016e5619108a2R331-R334) [[3]](diffhunk://#diff-fabb019e91e347b89a38879bbb26f5d9493b1157bd6fb4d7bb1016e5619108a2R352-R354) [[4]](diffhunk://#diff-fabb019e91e347b89a38879bbb26f5d9493b1157bd6fb4d7bb1016e5619108a2L369-R381) [[5]](diffhunk://#diff-fabb019e91e347b89a38879bbb26f5d9493b1157bd6fb4d7bb1016e5619108a2L382-R394) [[6]](diffhunk://#diff-fabb019e91e347b89a38879bbb26f5d9493b1157bd6fb4d7bb1016e5619108a2L392-R424)

These changes should result in better performance under high load and make the code easier to maintain and extend.