### PR TITLE
Add rio poll mode

### DIFF
--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -366,28 +366,6 @@ void worker_thread_func(client_worker_context* ctx, size_t payload_size) try {
 }
 
 /**
- * @brief Print usage/help text to stdout.
- */
-void print_usage(const char* program_name) {
-    std::cout
-        << "Usage: " << program_name << " [options]\n"
-        << "Options:\n"
-        << "  --server, -s <host>       - Server hostname or IP (required)\n"
-        << "  --port, -p <port>         - Server UDP port (required)\n"
-        << "  --payload, -l <bytes>     - Payload size in bytes (default: 64)\n"
-        << "  --cores, -c <n>           - Number of cores/workers to use (default: all)\n"
-        << "  --duration, -d <seconds>  - Test duration in seconds (default: 10)\n"
-        << "  --rate, -r <pps>          - Packets per second total across all workers (0 = "
-           "unlimited)\n"
-        << "  --recvbuf, -b <bytes>     - Socket receive buffer size in bytes (default: "
-           "4194304 = 4MB)\n"
-        << "  --sockets, -k <n>         - Number of sockets to create per worker (default: 1)\n"
-        << "  --verbose, -v             - Enable verbose logging (default: minimal)\n"
-        << "  --stats-file, -o <path>   - Write final run statistics as JSON to file\n"
-        << "  --help, -h                - Show this help\n";
-}
-
-/**
  * @brief Program entry point.
  *
  * Parses command-line arguments, initializes Winsock, creates worker
@@ -397,22 +375,22 @@ void print_usage(const char* program_name) {
 int main(int argc, char* argv[]) try {
     // Use ArgParser for command-line parsing
     ArgParser parser;
-    parser.add_option("verbose", 'v', "0", false);
-    parser.add_option("server", 's', "", true);
-    parser.add_option("port", 'p', "7", true);  // Note: The IANA-assigned port for echo is 7
-    parser.add_option("payload", 'l', "64", true);
-    parser.add_option("cores", 'c', "0", true);
-    parser.add_option("duration", 'd', "10", true);
-    parser.add_option("rate", 'r', "10000", true);
-    parser.add_option("recvbuf", 'b', "4194304", true);
-    parser.add_option("sockets", 'k', "16", true);
-    parser.add_option("stats-file", 'o', "", true);
-    parser.add_option("help", 'h', "0", false);
+    parser.add_option("verbose", 'v', "0", false, "Enable verbose logging");
+    parser.add_option("server", 's', "", true, "Server IP address or hostname");
+    parser.add_option("port", 'p', "7", true, "Server UDP port (default: 7)");
+    parser.add_option("payload", 'l', "64", true, "Payload size in bytes (default: 64)");
+    parser.add_option("cores", 'c', "0", true, "Number of CPU cores to use (default: all)");
+    parser.add_option("duration", 'd', "10", true, "Test duration in seconds (default: 10)");
+    parser.add_option("rate", 'r', "10000", true, "Total packet rate limit (packets/sec, 0=unlimited)");
+    parser.add_option("recvbuf", 'b', "4194304", true, "Socket receive buffer size in bytes (default: 4194304)");
+    parser.add_option("sockets", 'k', "16", true, "Number of sockets per worker (default: 16)");
+    parser.add_option("stats-file", 'o', "", true, "Output statistics to specified file");
+    parser.add_option("help", 'h', "0", false, "Show this help message");
 
     parser.parse(argc, argv);
 
     if (parser.is_set("help")) {
-        print_usage(argv[0]);
+        parser.print_help(argv[0]);
         return 0;
     }
 

--- a/src/common/socket_utils.hpp
+++ b/src/common/socket_utils.hpp
@@ -433,7 +433,7 @@ RIO_EXTENSION_FUNCTION_TABLE load_rio_function_table(const unique_socket& sock);
  * @throws socket_exception on failure.
  */
 unique_rio_cq create_rio_completion_queue(const RIO_EXTENSION_FUNCTION_TABLE& rio, DWORD queue_size,
-                                          unique_event& notification_event);
+                                          std::optional<unique_event>& notification_event);
 
 /**
  * @brief Create a RIO request queue for a socket.


### PR DESCRIPTION
This pull request refactors command-line argument handling and help text formatting for both client and server applications, and adds support for RIO poll mode to the server. The changes improve usability, clarity, and configurability, especially around Registered I/O (RIO) operation modes.

### Argument parsing and help text improvements

* Updated the `ArgParser` class to use `std::map` for deterministic option ordering and implemented a new `print_help` method that displays aligned, well-formatted help text including option descriptions and default values. This replaces the previous custom help-printing functions in both client and server. (`src/common/arg_parser.hpp`, `src/client/main.cpp`, `src/server/main.cpp`) [[1]](diffhunk://#diff-d2903e164ee90b8f29df93dbbd7cb9ccd97f567285fec1cc7bb564ed061662f1L19-R19) [[2]](diffhunk://#diff-d2903e164ee90b8f29df93dbbd7cb9ccd97f567285fec1cc7bb564ed061662f1R148-R186) [[3]](diffhunk://#diff-0ba42df560ab77c250cbab896ad90bd4f63568ff1fa11b5e2ee8eddfd2ed964dL368-L389) [[4]](diffhunk://#diff-fabb019e91e347b89a38879bbb26f5d9493b1157bd6fb4d7bb1016e5619108a2L524-L547)
* All command-line options in both client and server are now defined with descriptions, improving clarity for users. (`src/client/main.cpp`, `src/server/main.cpp`) [[1]](diffhunk://#diff-0ba42df560ab77c250cbab896ad90bd4f63568ff1fa11b5e2ee8eddfd2ed964dL400-R393) [[2]](diffhunk://#diff-fabb019e91e347b89a38879bbb26f5d9493b1157bd6fb4d7bb1016e5619108a2L556-R556)

### RIO poll mode support (server only)

* Added a new `--rio-poll-mode` command-line option to the server, allowing users to select RIO poll mode instead of event notification. This is reflected in configuration parsing and runtime output. (`src/server/main.cpp`) [[1]](diffhunk://#diff-fabb019e91e347b89a38879bbb26f5d9493b1157bd6fb4d7bb1016e5619108a2R570) [[2]](diffhunk://#diff-fabb019e91e347b89a38879bbb26f5d9493b1157bd6fb4d7bb1016e5619108a2L593-R582) [[3]](diffhunk://#diff-fabb019e91e347b89a38879bbb26f5d9493b1157bd6fb4d7bb1016e5619108a2R645-R646)
* Added logic in the RIO worker thread to support poll mode: when enabled, threads yield instead of waiting for event notifications if no completions are available. (`src/server/main.cpp`)
* The server now conditionally creates RIO completion queues with or without event notification, based on the poll mode setting, and the relevant API signature was updated to accept an optional event handle. (`src/common/socket_utils.cpp`, `src/common/socket_utils.hpp`, `src/server/main.cpp`) [[1]](diffhunk://#diff-bd5e89fe07dc5ec2382ba35184d0caf52a7e7f85a2eb2927dc4dabde2a47fe75L482-R495) [[2]](diffhunk://#diff-bd5e89fe07dc5ec2382ba35184d0caf52a7e7f85a2eb2927dc4dabde2a47fe75R505) [[3]](diffhunk://#diff-d4800f35c68e179c407fc8852583d68443dd4aef1ff093976cfb038a3744cabeL436-R436) [[4]](diffhunk://#diff-fabb019e91e347b89a38879bbb26f5d9493b1157bd6fb4d7bb1016e5619108a2R694-R700)