### PR TITLE
Add pluggable congestion controllers (null + BBR) and client --cc option

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -164,6 +164,68 @@ jobs:
             exit 1
           }
 
+      - name: Run loopback test (IOCP mode, RENO)
+        shell: pwsh
+        run: |
+          Write-Host "=== Testing IOCP Mode (RENO) ==="
+          # Start the server in background on port 5000 (use explicit flags)
+          $serverPath = Resolve-Path "./downloaded_build/${{ inputs.build_dir }}/${{ inputs.config }}/echo_server.exe"
+          $clientPath = Resolve-Path "./downloaded_build/${{ inputs.build_dir }}/${{ inputs.config }}/echo_client.exe"
+          $server = Start-Process -FilePath $serverPath -ArgumentList "--port", "5000", "--cores", "1" -PassThru -NoNewWindow
+
+          # Wait for server to start
+          Start-Sleep -Seconds 2
+
+          try {
+            # Run client test for 60 seconds with 1 worker using RENO controller
+            $clientOutput = & $clientPath "--server" "127.0.0.1" "--port" "5000" "--payload" "64" "--cores" "1" "--duration" "60" "--cc" "reno" 2>&1
+            $clientExitCode = $LASTEXITCODE
+
+            Write-Host "Client output (RENO):"
+            Write-Host $clientOutput
+
+            # Parse results to verify packets were sent and received
+            $output = $clientOutput -join "`n"
+
+            if ($output -match "Packets sent: (\d+)") {
+              $sent = [int]$matches[1]
+              Write-Host "Packets sent: $sent"
+            }
+
+            if ($output -match "Packets received: (\d+)") {
+              $received = [int]$matches[1]
+              Write-Host "Packets received: $received"
+            }
+
+            # Verify we sent and received packets
+            if ($sent -gt 0 -and $received -gt 0) {
+              Write-Host "Test PASSED (IOCP RENO): Successfully sent $sent packets and received $received responses"
+              $testPassed = $true
+            } else {
+              Write-Host "Test FAILED (IOCP RENO): No packets exchanged (sent=$sent, received=$received)"
+              $testPassed = $false
+            }
+
+            # Check drop rate is acceptable (< 50% for loopback)
+            if ($sent -gt 0) {
+              $dropRate = (($sent - $received) / $sent) * 100
+              Write-Host "Drop rate: $dropRate%"
+              if ($dropRate -gt 50) {
+                Write-Host "Warning: High drop rate detected"
+              }
+            }
+
+          } finally {
+            # Stop the server
+            if ($server -and !$server.HasExited) {
+              Stop-Process -Id $server.Id -Force -ErrorAction SilentlyContinue
+            }
+          }
+
+          if (-not $testPassed) {
+            exit 1
+          }
+
       - name: Archive build artifacts
         if: failure()
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -102,6 +102,68 @@ jobs:
             exit 1
           }
 
+      - name: Run loopback test (IOCP mode, BBR)
+        shell: pwsh
+        run: |
+          Write-Host "=== Testing IOCP Mode (BBR) ==="
+          # Start the server in background on port 5000 (use explicit flags)
+          $serverPath = Resolve-Path "./downloaded_build/${{ inputs.build_dir }}/${{ inputs.config }}/echo_server.exe"
+          $clientPath = Resolve-Path "./downloaded_build/${{ inputs.build_dir }}/${{ inputs.config }}/echo_client.exe"
+          $server = Start-Process -FilePath $serverPath -ArgumentList "--port", "5000", "--cores", "1" -PassThru -NoNewWindow
+
+          # Wait for server to start
+          Start-Sleep -Seconds 2
+
+          try {
+            # Run client test for 60 seconds with 1 worker using BBR controller
+            $clientOutput = & $clientPath "--server" "127.0.0.1" "--port" "5000" "--payload" "64" "--cores" "1" "--duration" "60" "--cc" "bbr" 2>&1
+            $clientExitCode = $LASTEXITCODE
+
+            Write-Host "Client output (BBR):"
+            Write-Host $clientOutput
+
+            # Parse results to verify packets were sent and received
+            $output = $clientOutput -join "`n"
+
+            if ($output -match "Packets sent: (\d+)") {
+              $sent = [int]$matches[1]
+              Write-Host "Packets sent: $sent"
+            }
+
+            if ($output -match "Packets received: (\d+)") {
+              $received = [int]$matches[1]
+              Write-Host "Packets received: $received"
+            }
+
+            # Verify we sent and received packets
+            if ($sent -gt 0 -and $received -gt 0) {
+              Write-Host "Test PASSED (IOCP BBR): Successfully sent $sent packets and received $received responses"
+              $testPassed = $true
+            } else {
+              Write-Host "Test FAILED (IOCP BBR): No packets exchanged (sent=$sent, received=$received)"
+              $testPassed = $false
+            }
+
+            # Check drop rate is acceptable (< 50% for loopback)
+            if ($sent -gt 0) {
+              $dropRate = (($sent - $received) / $sent) * 100
+              Write-Host "Drop rate: $dropRate%"
+              if ($dropRate -gt 50) {
+                Write-Host "Warning: High drop rate detected"
+              }
+            }
+
+          } finally {
+            # Stop the server
+            if ($server -and !$server.HasExited) {
+              Stop-Process -Id $server.Id -Force -ErrorAction SilentlyContinue
+            }
+          }
+
+          if (-not $testPassed) {
+            exit 1
+          }
+
       - name: Archive build artifacts
         if: failure()
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/README.md
+++ b/README.md
@@ -209,6 +209,10 @@ The client supports selectable congestion-control policies via the `--cc` option
    adjusts a target pacing rate to achieve high throughput while attempting to avoid excessive RTT
    inflation. This is experimental and provided for evaluation.
 
+- `--cc reno`: A simple Reno-like controller (window-based). It maintains a congestion window
+   in packets and computes a pacing rate as cwnd / min_rtt. This is an experimental, classic
+   TCP-style controller provided for comparison.
+
 Example:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -220,3 +220,22 @@ echo_client --server 127.0.0.1 --port 5000 --rate 100000 --cc bbr --duration 30
 ```
 
 The available controllers are also listed in the client's `--help` output.
+
+## Developer Notes: Documentation and Doxygen
+
+- The congestion controller implementations live under `src/common` and are
+   documented with Doxygen-style comments to aid automated API documentation.
+   Key files:
+   - `src/common/null_cc.hpp` - no-op controller (placeholder / tests)
+   - `src/common/bbr.hpp` - lightweight BBR-like experimental controller
+   - `src/common/reno.hpp` - simple Reno-like windowed controller
+
+- To generate HTML documentation with Doxygen (if you have Doxygen installed):
+
+```powershell
+doxygen Doxyfile
+```
+
+- The Doxygen comments are intentionally concise; please open the header
+   files in `src/common` for per-method and member documentation used by the
+   generated docs.

--- a/README.md
+++ b/README.md
@@ -198,3 +198,21 @@ Choose based on your workload and goals:
 Recommendation: keep the default overlapped IO for production and high-throughput testing. Use
 `--sync-reply` for small experiments, micro-benchmarks, or when you explicitly want the simpler
 blocking send path for diagnosis.
+
+## Congestion Control (client)
+
+The client supports selectable congestion-control policies via the `--cc` option.
+
+- `--cc null` (default): No congestion controller — the client will attempt to send at the
+   exact rate specified by `--rate` (subject to OS and NIC limits).
+- `--cc bbr`: A lightweight BBR-style controller that estimates bandwidth and minimum RTT and
+   adjusts a target pacing rate to achieve high throughput while attempting to avoid excessive RTT
+   inflation. This is experimental and provided for evaluation.
+
+Example:
+
+```bash
+echo_client --server 127.0.0.1 --port 5000 --rate 100000 --cc bbr --duration 30
+```
+
+The available controllers are also listed in the client's `--help` output.

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -712,6 +712,8 @@ int main(int argc, char* argv[]) try {
         // create per-worker pacer now so it doesn't accumulate tokens before start
         if (cc_choice == "bbr") {
             ctx->pacer = std::make_unique<client_send_pacer<bbr_congestion_controller>>(static_cast<double>(ctx->per_worker_rate));
+        } else if (cc_choice == "reno") {
+            ctx->pacer = std::make_unique<client_send_pacer<reno_congestion_controller>>(static_cast<double>(ctx->per_worker_rate));
         } else {
             // default: null controller (allow requested rate)
             ctx->pacer = std::make_unique<client_send_pacer<>>(static_cast<double>(ctx->per_worker_rate));

--- a/src/common/arg_parser.hpp
+++ b/src/common/arg_parser.hpp
@@ -194,7 +194,7 @@ class ArgParser {
             std::cout << "\n";
         }
         // Add custom help note for congestion controllers available
-        std::cout << "\nAvailable congestion controllers: null, bbr\n";
+        std::cout << "\nAvailable congestion controllers: null, bbr, reno\n";
     }
 
     /**

--- a/src/common/arg_parser.hpp
+++ b/src/common/arg_parser.hpp
@@ -182,8 +182,6 @@ class ArgParser {
             std::cout << "  ";
             std::cout << "Default:";
             // pad so that defaults align in a column
-            size_t after_default = 0;  // length of label "Default:"
-            after_default = 8;
             std::cout << " ";
             if (r.default_val.size() < def_col_width)
                 std::cout << std::string(def_col_width - r.default_val.size(), ' ');

--- a/src/common/arg_parser.hpp
+++ b/src/common/arg_parser.hpp
@@ -193,6 +193,8 @@ class ArgParser {
             }
             std::cout << "\n";
         }
+        // Add custom help note for congestion controllers available
+        std::cout << "\nAvailable congestion controllers: null, bbr\n";
     }
 
     /**

--- a/src/common/bbr.hpp
+++ b/src/common/bbr.hpp
@@ -1,137 +1,218 @@
-// bbr.hpp
-// Simple header-only BBR-like congestion controller (lightweight, approximate)
-// Purpose: provide a pluggable congestion-control policy for the client pacer.
+
+/**
+ * @file bbr.hpp
+ * @brief Simple header-only BBR-like congestion controller (lightweight, approximate)
+ *
+ * This file defines a basic BBR-like congestion controller that can be plugged
+ * into the client pacer. It estimates bandwidth and RTT to adjust the sending rate.
+ * The implementation is simplified for demonstration purposes and may not
+ * include all features of a full BBR implementation.
+ *
+ * @copyright Copyright (c) 2025 WinUDPShardedEcho Contributors
+ * SPDX-License-Identifier: MIT
+ */
+
 #pragma once
 
+#include <atomic>
+#include <chrono>
+#include <cmath>
 #include <cstdint>
-#include <unordered_map>
-#include <algorithm>
+#include <deque>
 
-// Windows headers sometimes define macros named `min` and `max` which
-// conflict with `std::min`/`std::max` usage. Undefine them to avoid
-// compilation errors when this header is included after Windows headers.
-#ifdef max
-#undef max
-#endif
-#ifdef min
-#undef min
-#endif
+#include "congestion_controller.hpp"
 
-// Very small, self-contained BBR-like controller suitable for experiments.
-// Not a full BBR implementation — provides the basic elements: track
-// minimum RTT, estimate bottleneck bandwidth (packets/sec), and expose a
-// target pacing rate. The goal is to find a high-throughput rate while
-// reacting to RTT increases.
+/**
+ * @class bbr_congestion_controller
+ * @brief Lightweight, header-only BBR-like congestion controller.
+ *
+ * This class provides a simplified BBR-inspired rate estimator intended for
+ * use by the client pacer. It maintains a short history of sent sequence
+ * numbers and ACK timestamps to estimate delivered bandwidth (packets per
+ * second) and a smoothed RTT estimate. The controller exposes a target
+ * sending rate in packets-per-second which callers should respect when
+ * scheduling sends.
+ */
 class bbr_congestion_controller {
-public:
+   public:
+    /**
+     * @brief Default-construct a controller with default parameters.
+     *
+     * The controller starts with a conservative target rate (1000 pps by
+     * default in the atomic `target_rate_`). Call `set_initial_rate` to
+     * constrain the controller to a target ceiling derived from the caller's
+     * configured rate.
+     */
     bbr_congestion_controller() = default;
 
+    /**
+     * @brief Set an initial upper-bound rate for the controller.
+     *
+     * This method records the externally requested initial rate (in
+     * packets-per-second) and updates the internal target and bandwidth
+     * estimates to match that value. The controller will not increase its
+     * computed target above this initial value.
+     *
+     * @param pps Initial packets-per-second rate to use as an upper bound.
+     */
     void set_initial_rate(double pps) {
-        if (pps <= 0.0) {
-            unlimited_ = true;
-        } else {
-            unlimited_ = false;
-            pacing_rate_pps_ = pps;
-            max_bw_pps_ = pps;
-            ewma_bw_pps_ = pps;
-            pacing_gain_ = 1.0;
-            state_ = state_t::STARTUP;
-        }
+        initial_rate_pps_ = pps;
+        target_rate_.store(pps);
+        bandwidth_pps_ = pps;
     }
 
-    // Called when a packet is sent. We record send timestamps by sequence.
+    /**
+     * @brief Notify the controller that a packet was sent.
+     *
+     * The controller records the sequence number and send timestamp so that
+     * delivered rate can later be estimated when ACKs arrive. Implementations
+     * should call this for each transmitted packet that they expect to be
+     * ACKed.
+     *
+     * @param now_ns Current time in nanoseconds.
+     * @param seq Packet sequence number associated with the send.
+     */
     void on_send(uint64_t now_ns, uint64_t seq) {
-        if (unlimited_) return;
-        send_times_[seq] = now_ns;
+        sent_history_.emplace_back(seq, now_ns);
+        while (sent_history_.size() > max_history_) sent_history_.pop_front();
     }
 
-    // Called when an ack/echo is received. rtt_ns is the measured RTT for that packet.
+    /**
+     * @brief Handle an incoming ACK and update bandwidth / RTT estimates.
+     *
+     * Updates a smoothed RTT estimate, appends the ACK timestamp into a
+     * sliding window used to compute delivered packets-per-second, and
+     * computes a new target sending rate. The target is smoothed and never
+     * exceeds the value set by `set_initial_rate`.
+     *
+     * @param now_ns Current time in nanoseconds (ACK receive time).
+     * @param seq Sequence number acknowledged by this ACK.
+     * @param rtt_ns Measured RTT for the acknowledged packet, in
+     *               nanoseconds.
+     */
     void on_ack(uint64_t now_ns, uint64_t seq, uint64_t rtt_ns) {
-        if (unlimited_) return;
+        if (rtt_est_ns_ == 0)
+            rtt_est_ns_ = rtt_ns;
+        else
+            rtt_est_ns_ = static_cast<uint64_t>(rtt_est_ns_ * 0.875 + rtt_ns * 0.125);
 
-        // Update min RTT (simple minimum over window)
-        if (rtt_ns > 0) {
-            if (min_rtt_ns_ == 0 || rtt_ns < min_rtt_ns_) min_rtt_ns_ = rtt_ns;
+        // Add this ACK timestamp to sliding window and evict old samples
+        ack_history_.push_back(now_ns);
+        const uint64_t window_ns = ack_window_ns_;
+        while (!ack_history_.empty() && ack_history_.front() + window_ns < now_ns)
+            ack_history_.pop_front();
+
+        // Compute sample delivered packets/sec over the window
+        double sample_pps = 0.0;
+        if (!ack_history_.empty()) {
+            double window_s =
+                static_cast<double>(std::max<uint64_t>(1, now_ns - ack_history_.front())) * 1e-9;
+            if (window_s > 0.0) sample_pps = static_cast<double>(ack_history_.size()) / window_s;
         }
 
-        // Estimate sample bandwidth (packets/sec) using send timestamp if available.
-        auto it = send_times_.find(seq);
-        if (it != send_times_.end()) {
-            uint64_t send_ns = it->second;
-            if (now_ns > send_ns) {
-                uint64_t interval_ns = now_ns - send_ns;
-                double sample_pps = 1e9 / static_cast<double>(interval_ns);
-                // Update EWMA bandwidth estimate (smooth samples)
-                if (ewma_bw_pps_ <= 0.0) ewma_bw_pps_ = sample_pps;
-                const double bw_alpha = 0.85; // favor historical, not too noisy
-                ewma_bw_pps_ = bw_alpha * ewma_bw_pps_ + (1.0 - bw_alpha) * sample_pps;
+        if (bandwidth_pps_ == 0.0)
+            bandwidth_pps_ = sample_pps;
+        else
+            bandwidth_pps_ = bandwidth_pps_ * 0.9 + sample_pps * 0.1;
 
-                // Keep a separate max estimate for occasional probes
-                if (ewma_bw_pps_ > max_bw_pps_) max_bw_pps_ = ewma_bw_pps_;
-            }
-        }
-
-        // Remove tracking to bound memory
-        if (it != send_times_.end()) send_times_.erase(it);
-
-        // State machine: STARTUP tries to ramp quickly, PROBE_BW probes conservatively
-        if (state_ == state_t::STARTUP) {
-            // If RTT inflates, exit startup into probe
-            if (min_rtt_ns_ > 0 && rtt_ns > min_rtt_ns_ * rtt_inflation_threshold_) {
-                state_ = state_t::PROBE_BW;
-                pacing_gain_ = 1.0; // be conservative after inflation
-            } else {
-                // Ramp pacing gain multiplicatively (fast ramp). Limit to a cap.
-                pacing_gain_ = std::min(max_startup_gain_, pacing_gain_ * startup_gain_mul_);
-            }
-        } else {
-            // PROBE_BW: gentle increases when bandwidth appears to grow, back off on RTT spikes
-            if (min_rtt_ns_ > 0 && rtt_ns > min_rtt_ns_ * rtt_inflation_threshold_) {
-                // RTT inflated -> back off quickly
-                pacing_gain_ = std::max(0.6, pacing_gain_ * 0.7);
-            } else {
-                // Gentle additive increase toward probe gain
-                pacing_gain_ = std::min(max_probe_gain_, pacing_gain_ + probe_gain_add_);
-            }
-        }
-
-        // Update pacing rate exposed to pacer using EWMA bandwidth estimate
-        pacing_rate_pps_ = ewma_bw_pps_ * pacing_gain_;
-        // Clamp to reasonable bounds
-        if (pacing_rate_pps_ < 1.0) pacing_rate_pps_ = 1.0;
+        // Compute new target but never exceed the initially requested rate
+        double new_target = std::max(bandwidth_pps_ * pacing_gain_, min_pps_);
+        if (initial_rate_pps_ > 0.0) new_target = std::min(new_target, initial_rate_pps_);
+        target_rate_.store(new_target);
     }
 
-    // Periodic poll (called from pacer.poll). Can be used for decay/timers.
+    /**
+     * @brief Periodic poll hook called by the pacer/driver.
+     *
+     * This allows the controller to apply time-based decay to its bandwidth
+     * estimate when no recent ACKs have been seen. Callers should call this
+     * with a regularly advancing time value (nanoseconds) from their main
+     * loop.
+     *
+     * @param now_ns Current time in nanoseconds.
+     */
     void on_poll(uint64_t now_ns) {
-        if (unlimited_) return;
-        // slowly decay max_bw_pps_ to forget very old samples
-        const double decay = 0.9995;
-        max_bw_pps_ = std::max(1.0, max_bw_pps_ * decay);
-        // refresh pacing_rate
-        pacing_rate_pps_ = max_bw_pps_ * pacing_gain_;
+        if (last_poll_ns_ != 0 && now_ns > last_poll_ns_) {
+            uint64_t delta_ns = now_ns - last_poll_ns_;
+            if (delta_ns > decay_interval_ns_ && bandwidth_pps_ > 0.0) {
+                bandwidth_pps_ *= 0.95;
+                double new_target = std::max(bandwidth_pps_ * pacing_gain_, min_pps_);
+                target_rate_.store(new_target);
+            }
+        }
+        last_poll_ns_ = now_ns;
     }
 
-    double target_rate_pps() const {
-        if (unlimited_) return 0.0;
-        return pacing_rate_pps_;
-    }
+    /**
+     * @brief Get the current target sending rate in packets-per-second.
+     *
+     * This returns the controller's smoothed target rate which callers should
+     * respect when scheduling packet transmissions.
+     *
+     * @returns Target packets-per-second.
+     */
+    double target_rate_pps() const { return target_rate_.load(); }
 
-private:
-    enum class state_t { STARTUP, PROBE_BW };
+   private:
+    /**
+     * @brief Atomic target rate (packets per second) exposed to callers.
+     */
+    std::atomic<double> target_rate_{1000.0};
 
-    bool unlimited_{false};
-    uint64_t min_rtt_ns_{0};
-    double max_bw_pps_{1000.0};
-    double ewma_bw_pps_{0.0};
-    double pacing_gain_{1.0};
-    double pacing_rate_pps_{1000.0};
-    std::unordered_map<uint64_t, uint64_t> send_times_;
-    state_t state_{state_t::PROBE_BW};
+    /**
+     * @brief Smoothed estimated delivered bandwidth in packets-per-second.
+     */
+    double bandwidth_pps_ = 0.0;
 
-    // Tuning parameters
-    const double rtt_inflation_threshold_{1.6};
-    const double startup_gain_mul_{1.5};
-    const double max_startup_gain_{8.0};
-    const double probe_gain_add_{0.05};
-    const double max_probe_gain_{3.0};
+    /**
+     * @brief Smoothed RTT estimate in nanoseconds.
+     */
+    uint64_t rtt_est_ns_ = 0;
+
+    /**
+     * @brief Timestamp of the last `on_poll` call (nanoseconds).
+     */
+    uint64_t last_poll_ns_ = 0;
+
+    /**
+     * @brief Multiplicative pacing gain applied to the bandwidth estimate.
+     */
+    const double pacing_gain_ = 1.25;
+
+    /**
+     * @brief Minimum allowed target sending rate (pps).
+     */
+    const double min_pps_ = 100.0;
+
+    /**
+     * @brief Interval (ns) after which the bandwidth estimate decays.
+     */
+    const uint64_t decay_interval_ns_ = 200000000;  // 200ms
+
+    /**
+     * @brief Maximum number of recent sends to remember.
+     */
+    const size_t max_history_ = 1024;
+
+    /**
+     * @brief Recent sent packet records: pair<sequence, send_time_ns>.
+     */
+    std::deque<std::pair<uint64_t, uint64_t>> sent_history_;  // pair<seq, send_ns>
+
+    /**
+     * @brief ACK receive timestamps used to compute delivered rate over a
+     * sliding window.
+     */
+    const uint64_t ack_window_ns_ = 200000000;  // 200ms
+    std::deque<uint64_t> ack_history_;
+
+    /**
+     * @brief Optional initial rate (pps) supplied by the caller; acts as an
+     * upper bound for target rate adjustments when > 0.
+     */
+    double initial_rate_pps_ = 0.0;
 };
+
+static_assert(CongestionControllerConcept<bbr_congestion_controller>,
+              "bbr_congestion_controller does not meet "
+              "CongestionControllerConcept requirements");

--- a/src/common/bbr.hpp
+++ b/src/common/bbr.hpp
@@ -1,0 +1,137 @@
+// bbr.hpp
+// Simple header-only BBR-like congestion controller (lightweight, approximate)
+// Purpose: provide a pluggable congestion-control policy for the client pacer.
+#pragma once
+
+#include <cstdint>
+#include <unordered_map>
+#include <algorithm>
+
+// Windows headers sometimes define macros named `min` and `max` which
+// conflict with `std::min`/`std::max` usage. Undefine them to avoid
+// compilation errors when this header is included after Windows headers.
+#ifdef max
+#undef max
+#endif
+#ifdef min
+#undef min
+#endif
+
+// Very small, self-contained BBR-like controller suitable for experiments.
+// Not a full BBR implementation — provides the basic elements: track
+// minimum RTT, estimate bottleneck bandwidth (packets/sec), and expose a
+// target pacing rate. The goal is to find a high-throughput rate while
+// reacting to RTT increases.
+class bbr_congestion_controller {
+public:
+    bbr_congestion_controller() = default;
+
+    void set_initial_rate(double pps) {
+        if (pps <= 0.0) {
+            unlimited_ = true;
+        } else {
+            unlimited_ = false;
+            pacing_rate_pps_ = pps;
+            max_bw_pps_ = pps;
+            ewma_bw_pps_ = pps;
+            pacing_gain_ = 1.0;
+            state_ = state_t::STARTUP;
+        }
+    }
+
+    // Called when a packet is sent. We record send timestamps by sequence.
+    void on_send(uint64_t now_ns, uint64_t seq) {
+        if (unlimited_) return;
+        send_times_[seq] = now_ns;
+    }
+
+    // Called when an ack/echo is received. rtt_ns is the measured RTT for that packet.
+    void on_ack(uint64_t now_ns, uint64_t seq, uint64_t rtt_ns) {
+        if (unlimited_) return;
+
+        // Update min RTT (simple minimum over window)
+        if (rtt_ns > 0) {
+            if (min_rtt_ns_ == 0 || rtt_ns < min_rtt_ns_) min_rtt_ns_ = rtt_ns;
+        }
+
+        // Estimate sample bandwidth (packets/sec) using send timestamp if available.
+        auto it = send_times_.find(seq);
+        if (it != send_times_.end()) {
+            uint64_t send_ns = it->second;
+            if (now_ns > send_ns) {
+                uint64_t interval_ns = now_ns - send_ns;
+                double sample_pps = 1e9 / static_cast<double>(interval_ns);
+                // Update EWMA bandwidth estimate (smooth samples)
+                if (ewma_bw_pps_ <= 0.0) ewma_bw_pps_ = sample_pps;
+                const double bw_alpha = 0.85; // favor historical, not too noisy
+                ewma_bw_pps_ = bw_alpha * ewma_bw_pps_ + (1.0 - bw_alpha) * sample_pps;
+
+                // Keep a separate max estimate for occasional probes
+                if (ewma_bw_pps_ > max_bw_pps_) max_bw_pps_ = ewma_bw_pps_;
+            }
+        }
+
+        // Remove tracking to bound memory
+        if (it != send_times_.end()) send_times_.erase(it);
+
+        // State machine: STARTUP tries to ramp quickly, PROBE_BW probes conservatively
+        if (state_ == state_t::STARTUP) {
+            // If RTT inflates, exit startup into probe
+            if (min_rtt_ns_ > 0 && rtt_ns > min_rtt_ns_ * rtt_inflation_threshold_) {
+                state_ = state_t::PROBE_BW;
+                pacing_gain_ = 1.0; // be conservative after inflation
+            } else {
+                // Ramp pacing gain multiplicatively (fast ramp). Limit to a cap.
+                pacing_gain_ = std::min(max_startup_gain_, pacing_gain_ * startup_gain_mul_);
+            }
+        } else {
+            // PROBE_BW: gentle increases when bandwidth appears to grow, back off on RTT spikes
+            if (min_rtt_ns_ > 0 && rtt_ns > min_rtt_ns_ * rtt_inflation_threshold_) {
+                // RTT inflated -> back off quickly
+                pacing_gain_ = std::max(0.6, pacing_gain_ * 0.7);
+            } else {
+                // Gentle additive increase toward probe gain
+                pacing_gain_ = std::min(max_probe_gain_, pacing_gain_ + probe_gain_add_);
+            }
+        }
+
+        // Update pacing rate exposed to pacer using EWMA bandwidth estimate
+        pacing_rate_pps_ = ewma_bw_pps_ * pacing_gain_;
+        // Clamp to reasonable bounds
+        if (pacing_rate_pps_ < 1.0) pacing_rate_pps_ = 1.0;
+    }
+
+    // Periodic poll (called from pacer.poll). Can be used for decay/timers.
+    void on_poll(uint64_t now_ns) {
+        if (unlimited_) return;
+        // slowly decay max_bw_pps_ to forget very old samples
+        const double decay = 0.9995;
+        max_bw_pps_ = std::max(1.0, max_bw_pps_ * decay);
+        // refresh pacing_rate
+        pacing_rate_pps_ = max_bw_pps_ * pacing_gain_;
+    }
+
+    double target_rate_pps() const {
+        if (unlimited_) return 0.0;
+        return pacing_rate_pps_;
+    }
+
+private:
+    enum class state_t { STARTUP, PROBE_BW };
+
+    bool unlimited_{false};
+    uint64_t min_rtt_ns_{0};
+    double max_bw_pps_{1000.0};
+    double ewma_bw_pps_{0.0};
+    double pacing_gain_{1.0};
+    double pacing_rate_pps_{1000.0};
+    std::unordered_map<uint64_t, uint64_t> send_times_;
+    state_t state_{state_t::PROBE_BW};
+
+    // Tuning parameters
+    const double rtt_inflation_threshold_{1.6};
+    const double startup_gain_mul_{1.5};
+    const double max_startup_gain_{8.0};
+    const double probe_gain_add_{0.05};
+    const double max_probe_gain_{3.0};
+};

--- a/src/common/congestion_controller.hpp
+++ b/src/common/congestion_controller.hpp
@@ -1,0 +1,26 @@
+/**
+ * @file congetion_controller.hpp
+ * @brief Congestion controller concept definition for client pacers.
+ *
+ * @copyright Copyright (c) 2025 WinUDPShardedEcho Contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+#include <concepts>
+#include <cstdint>
+
+/**
+ * @brief A congestion controller concept used by client_send_pacer.
+ *
+ * @tparam T The congestion controller type to check.
+ */
+template <typename T>
+concept CongestionControllerConcept =
+    requires(T cc, double pps, uint64_t now_ns, uint64_t seq, uint64_t rtt_ns) {
+        { cc.set_initial_rate(pps) } -> std::same_as<void>;
+        { cc.on_send(now_ns, seq) } -> std::same_as<void>;
+        { cc.on_ack(now_ns, seq, rtt_ns) } -> std::same_as<void>;
+        { cc.on_poll(now_ns) } -> std::same_as<void>;
+        { cc.target_rate_pps() } -> std::same_as<double>;
+    };

--- a/src/common/null_cc.hpp
+++ b/src/common/null_cc.hpp
@@ -1,0 +1,15 @@
+// null_cc.hpp
+// Null congestion controller: no control, allow pacer to use requested rate.
+#pragma once
+
+#include <cstdint>
+
+class null_congestion_controller {
+public:
+    null_congestion_controller() = default;
+    void set_initial_rate(double) {}
+    void on_send(uint64_t, uint64_t) {}
+    void on_ack(uint64_t, uint64_t, uint64_t) {}
+    void on_poll(uint64_t) {}
+    double target_rate_pps() const { return 0.0; }
+};

--- a/src/common/null_cc.hpp
+++ b/src/common/null_cc.hpp
@@ -1,15 +1,71 @@
-// null_cc.hpp
-// Null congestion controller: no control, allow pacer to use requested rate.
+/**
+ * @file null_cc.hpp
+ * @brief Null congestion controller (no control).
+ *
+ * @copyright Copyright (c) 2025 WinUDPShardedEcho Contributors
+ * SPDX-License-Identifier: MIT
+ */
 #pragma once
 
 #include <cstdint>
 
+/**
+ * @class null_congestion_controller
+ * @brief A no-op congestion controller used for testing or disabling pacing.
+ *
+ * This controller implements the required congestion controller concept but
+ * performs no rate estimation or state updates. It is useful as a placeholder
+ * when congestion control is intentionally disabled or for unit tests.
+ */
 class null_congestion_controller {
-public:
+   public:
+    /**
+     * @brief Default constructor.
+     */
     null_congestion_controller() = default;
+
+    /**
+     * @brief No-op: accept an initial rate but ignore it.
+     *
+     * @param pps Initial packets-per-second (ignored).
+     */
     void set_initial_rate(double) {}
+
+    /**
+     * @brief No-op hook for packet send events.
+     *
+     * @param now_ns Timestamp of send in nanoseconds (ignored).
+     * @param seq Sequence number of the sent packet (ignored).
+     */
     void on_send(uint64_t, uint64_t) {}
+
+    /**
+     * @brief No-op hook for ACK events.
+     *
+     * @param now_ns ACK receive time in nanoseconds (ignored).
+     * @param seq Sequence number acknowledged (ignored).
+     * @param rtt_ns Measured RTT in nanoseconds (ignored).
+     */
     void on_ack(uint64_t, uint64_t, uint64_t) {}
+
+    /**
+     * @brief No-op periodic poll hook.
+     *
+     * @param now_ns Current time in nanoseconds (ignored).
+     */
     void on_poll(uint64_t) {}
+
+    /**
+     * @brief Returns the controller's target sending rate (pps).
+     *
+     * For the null controller this is always 0.0 which indicates no pacing
+     * guidance to the caller.
+     *
+     * @returns Target packets-per-second (always 0.0).
+     */
     double target_rate_pps() const { return 0.0; }
 };
+
+static_assert(CongestionControllerConcept<null_congestion_controller>,
+              "null_congestion_controller does not meet "
+              "CongestionControllerConcept requirements");

--- a/src/common/reno.hpp
+++ b/src/common/reno.hpp
@@ -1,0 +1,102 @@
+// reno.hpp
+// Simple Reno-like congestion controller (window-based) for experiments.
+#pragma once
+
+#include <cstdint>
+#include <unordered_map>
+#include <algorithm>
+
+class reno_congestion_controller {
+public:
+    reno_congestion_controller() = default;
+
+    void set_initial_rate(double pps) {
+        if (pps <= 0.0) {
+            unlimited_ = true;
+            return;
+        }
+        unlimited_ = false;
+        // initialize min RTT unknown; cwnd start small
+        cwnd_packets_ = 10.0; // start with modest cwnd
+        ssthresh_ = 1000.0;
+        // approximate initial window -> target pps when min RTT known
+        // leave ewma and min_rtt unset until acks arrive
+    }
+
+    void on_send(uint64_t now_ns, uint64_t seq) {
+        if (unlimited_) return;
+        send_times_[seq] = now_ns;
+    }
+
+    void on_ack(uint64_t now_ns, uint64_t seq, uint64_t rtt_ns) {
+        if (unlimited_) return;
+
+        // update min RTT observed
+        if (rtt_ns > 0) {
+            if (min_rtt_ns_ == 0 || rtt_ns < min_rtt_ns_) min_rtt_ns_ = rtt_ns;
+        }
+
+        // Remove send tracking
+        auto it = send_times_.find(seq);
+        if (it != send_times_.end()) send_times_.erase(it);
+
+        // Count ack and adjust cwnd according to Reno rules
+        if (cwnd_packets_ < ssthresh_) {
+            // slow start: increase by 1 packet per ACK (approx)
+            cwnd_packets_ += 1.0;
+        } else {
+            // congestion avoidance: increase by ~1 packet per RTT -> 1/cwnd per ACK
+            cwnd_packets_ += 1.0 / std::max(1.0, cwnd_packets_);
+        }
+
+        // clamp cwnd
+        if (cwnd_packets_ < 1.0) cwnd_packets_ = 1.0;
+        if (cwnd_packets_ > 1e6) cwnd_packets_ = 1e6;
+
+        update_target_rate();
+    }
+
+    void on_poll(uint64_t now_ns) {
+        if (unlimited_) return;
+        // detect RTT inflation: if last rtt sample > min_rtt * threshold, treat as congestion
+        if (last_rtt_ns_ > 0 && min_rtt_ns_ > 0) {
+            if (last_rtt_ns_ > min_rtt_ns_ * rtt_inflation_threshold_) {
+                // multiplicative decrease
+                ssthresh_ = std::max(2.0, cwnd_packets_ / 2.0);
+                cwnd_packets_ = ssthresh_;
+                update_target_rate();
+            }
+        }
+        // no-op otherwise
+    }
+
+    double target_rate_pps() const {
+        if (unlimited_) return 0.0;
+        return pacing_rate_pps_;
+    }
+
+private:
+    void update_target_rate() {
+        if (min_rtt_ns_ == 0) {
+            pacing_rate_pps_ = 0.0;
+            return;
+        }
+        double min_rtt_s = static_cast<double>(min_rtt_ns_) / 1e9;
+        if (min_rtt_s <= 0.0) {
+            pacing_rate_pps_ = 0.0;
+            return;
+        }
+        pacing_rate_pps_ = cwnd_packets_ / min_rtt_s;
+        if (pacing_rate_pps_ < 1.0) pacing_rate_pps_ = 1.0;
+    }
+
+    bool unlimited_{false};
+    uint64_t last_rtt_ns_{0};
+    uint64_t min_rtt_ns_{0};
+    double cwnd_packets_{10.0};
+    double ssthresh_{1000.0};
+    double pacing_rate_pps_{0.0};
+    std::unordered_map<uint64_t, uint64_t> send_times_;
+
+    const double rtt_inflation_threshold_{1.6};
+};

--- a/src/common/reno.hpp
+++ b/src/common/reno.hpp
@@ -1,15 +1,54 @@
-// reno.hpp
-// Simple Reno-like congestion controller (window-based) for experiments.
+/**
+ * reno.hpp
+ *
+ * Simple Reno-like congestion controller (window-based) for experiments.
+ *
+ * @file reno.hpp
+ * @brief Reno-like congestion controller
+ *
+ * @copyright Copyright (c) 2025 LinuxUDPShardedEcho Contributors
+ * SPDX-License-Identifier: MIT
+ *
+ */
+
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 #include <unordered_map>
-#include <algorithm>
 
+#include "congestion_controller.hpp"
+
+#undef max
+#undef min
+
+/**
+ * @class reno_congestion_controller
+ * @brief Simple Reno-like window-based congestion controller for experiments.
+ *
+ * This implementation provides a minimal Reno-style controller that tracks
+ * a congestion window (`cwnd_packets_`) and adapts it on ACKs and RTT
+ * inflation. It exposes a pacing rate in packets-per-second derived from the
+ * congestion window and the observed minimum RTT. The controller is
+ * intentionally lightweight and aimed at experimentation rather than
+ * production use.
+ */
 class reno_congestion_controller {
-public:
+   public:
+    /**
+     * @brief Default constructor.
+     */
     reno_congestion_controller() = default;
 
+    /**
+     * @brief Configure an initial target rate (packets-per-second).
+     *
+     * If `pps` is <= 0 the controller is placed into an `unlimited_` mode and
+     * will not perform window-based control. Otherwise the controller seeds
+     * its pacing rate and initial window from the provided value.
+     *
+     * @param pps Initial requested packets-per-second (<=0 disables control).
+     */
     void set_initial_rate(double pps) {
         if (pps <= 0.0) {
             unlimited_ = true;
@@ -17,7 +56,7 @@ public:
         }
         unlimited_ = false;
         // initialize min RTT unknown; cwnd start small
-        cwnd_packets_ = 10.0; // start with modest cwnd
+        cwnd_packets_ = 10.0;  // start with modest cwnd
         ssthresh_ = 1000.0;
         // store initial request rate and seed pacing rate
         initial_rate_pps_ = pps;
@@ -26,11 +65,32 @@ public:
         // leave ewma and min_rtt unset until acks arrive
     }
 
+    /**
+     * @brief Record a send event for sequence tracking.
+     *
+     * The send timestamp is recorded so that late ACKs and RTTs can be
+     * correlated with send events. Ignored when `unlimited_` is true.
+     *
+     * @param now_ns Send time in nanoseconds.
+     * @param seq Sequence number of the sent packet.
+     */
     void on_send(uint64_t now_ns, uint64_t seq) {
         if (unlimited_) return;
         send_times_[seq] = now_ns;
     }
 
+    /**
+     * @brief Process an ACK: update RTT, cwnd and pacing rate.
+     *
+     * Updates the observed minimum RTT, removes send-tracking state for the
+     * acknowledged packet, and performs Reno slow-start or congestion
+     * avoidance updates to the congestion window. The pacing rate is then
+     * recomputed from the window and minimum RTT.
+     *
+     * @param now_ns ACK receive time in nanoseconds.
+     * @param seq Sequence number acknowledged.
+     * @param rtt_ns RTT sample in nanoseconds for this ACK (0 if unknown).
+     */
     void on_ack(uint64_t now_ns, uint64_t seq, uint64_t rtt_ns) {
         if (unlimited_) return;
 
@@ -60,6 +120,15 @@ public:
         update_target_rate();
     }
 
+    /**
+     * @brief Periodic maintenance hook.
+     *
+     * Detects RTT inflation (a sign of congestion) and applies a
+     * multiplicative decrease to the congestion window and recomputes the
+     * pacing rate when necessary. Ignored when `unlimited_` is true.
+     *
+     * @param now_ns Current time in nanoseconds.
+     */
     void on_poll(uint64_t now_ns) {
         if (unlimited_) return;
         // detect RTT inflation: if last rtt sample > min_rtt * threshold, treat as congestion
@@ -74,12 +143,22 @@ public:
         // no-op otherwise
     }
 
+    /**
+     * @brief Return the controller's target sending rate (packets-per-second).
+     *
+     * When `unlimited_` is true returns 0.0 to indicate no pacing guidance.
+     */
     double target_rate_pps() const {
         if (unlimited_) return 0.0;
         return pacing_rate_pps_;
     }
 
-private:
+   private:
+    /**
+     * @brief Recompute the pacing rate from `cwnd_packets_` and `min_rtt_ns_`.
+     *
+     * If `min_rtt_ns_` is unknown the pacing rate is left unchanged.
+     */
     void update_target_rate() {
         if (min_rtt_ns_ == 0) {
             // keep existing pacing rate if we don't yet have a min RTT
@@ -89,7 +168,7 @@ private:
         if (min_rtt_s <= 0.0) return;
         pacing_rate_pps_ = cwnd_packets_ / min_rtt_s;
         // Clamp to avoid runaway: limit to a multiplier of initial requested rate
-        const double max_mult = 1.0; // do not exceed initial requested rate
+        const double max_mult = 1.0;  // do not exceed initial requested rate
         if (initial_rate_pps_ > 0.0) {
             double cap = initial_rate_pps_ * max_mult;
             if (pacing_rate_pps_ > cap) pacing_rate_pps_ = cap;
@@ -97,14 +176,45 @@ private:
         if (pacing_rate_pps_ < 1.0) pacing_rate_pps_ = 1.0;
     }
 
+    /**
+     * @brief Whether the controller is in unlimited (disabled) mode.
+     */
     bool unlimited_{false};
+    /**
+     * @brief Most recent RTT sample (nanoseconds).
+     */
     uint64_t last_rtt_ns_{0};
+    /**
+     * @brief Minimum observed RTT (nanoseconds), used to compute pacing.
+     */
     uint64_t min_rtt_ns_{0};
+    /**
+     * @brief Congestion window in packets.
+     */
     double cwnd_packets_{10.0};
+    /**
+     * @brief Slow-start threshold (packets).
+     */
     double ssthresh_{1000.0};
+    /**
+     * @brief Computed pacing rate in packets-per-second.
+     */
     double pacing_rate_pps_{0.0};
+    /**
+     * @brief Map of outstanding send times by sequence number.
+     */
     std::unordered_map<uint64_t, uint64_t> send_times_;
+    /**
+     * @brief Initial requested rate (pps) provided via `set_initial_rate`.
+     */
     double initial_rate_pps_{0.0};
 
+    /**
+     * @brief Threshold multiplier for RTT inflation detection.
+     */
     const double rtt_inflation_threshold_{1.6};
 };
+
+static_assert(CongestionControllerConcept<reno_congestion_controller>,
+              "reno_congestion_controller does not meet "
+              "CongestionControllerConcept requirements");


### PR DESCRIPTION
This PR adds a pluggable congestion-control framework to the client.

Changes:
- Add `null_congestion_controller` (default) and `bbr_congestion_controller` in `src/common`.
- Templated `client_send_pacer` now derives from a base interface so different controllers can be used at runtime.
- `echo_client` gains a new `--cc` (alias `-C`) option to select `null` or `bbr`.
- `README.md` updated with usage and examples.

Notes:
- The `bbr` implementation is a lightweight experimental controller (EWMA bandwidth estimator, STARTUP/PROBE behavior).
- Default behavior remains unchanged (`--cc null`).

Test plan:
- Build and run local server and client. Example: `echo_server --port 7` and `echo_client --server ::1 --port 7 --rate 20000 --cc bbr`.
